### PR TITLE
Patch Struct

### DIFF
--- a/struct.go
+++ b/struct.go
@@ -208,7 +208,7 @@ func (_struct *Struct) rangeStruct(fields map[int]reflect.Value) {
 
 			fields[k].Set(tmp)
 		default:
-			fields[k].Set(v)
+			fields[k].Set(v.Convert(fields[k].Type()))
 		}
 	}
 }


### PR DESCRIPTION
This pull request fixes an issue with `struct.go` where a fields[k] type might be a custom type so convert v to match it