### PR TITLE
Struct Field Interface

### DIFF
--- a/struct.go
+++ b/struct.go
@@ -172,6 +172,11 @@ func (_struct *Struct) rangeStruct(fields map[int]reflect.Value) {
 			fields[k].Set(m)
 			continue
 		case reflect.Struct:
+			if fields[k].Kind() == reflect.Interface {
+				fields[k].Set(_struct.m[k])
+				continue
+			}
+
 			s, ok := _struct.Get(k)
 			if !ok {
 				continue


### PR DESCRIPTION
This pull request fixes a bug regarding structures with `interface{}` fields where it's a struct.
