### PR TITLE
Depth

### DIFF
--- a/depth.go
+++ b/depth.go
@@ -72,3 +72,17 @@ func isMixed(t reflect.Type) bool {
 	}
 }
 
+func fromDepth(t reflect.Type, d int, di []int) reflect.Type {
+	slices.Reverse(di)
+
+	for i := 0; i < d; i++ {
+		if di == nil || di[i] == 0 {
+			t = reflect.SliceOf(t)
+			continue
+		}
+
+		t = reflect.ArrayOf(di[i], t)
+	}
+
+	return t
+}

--- a/depth.go
+++ b/depth.go
@@ -54,3 +54,21 @@ func depth(value reflect.Value) (reflect.Type, int, bool, []int) {
 	}
 }
 
+func isMixed(t reflect.Type) bool {
+	pt := t
+
+	for {
+		switch t.Elem().Kind() {
+		case reflect.Array, reflect.Slice:
+			if t.Elem().Kind() == pt.Kind() {
+				pt = t
+				t = t.Elem()
+				continue
+			}
+			return true
+		default:
+			return false
+		}
+	}
+}
+

--- a/depth.go
+++ b/depth.go
@@ -1,0 +1,20 @@
+/*
+ *     A tiny format for using binary data
+ *     Copyright (C) 2024  Dviih
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published
+ *     by the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package bin

--- a/depth.go
+++ b/depth.go
@@ -24,3 +24,33 @@ import (
 	"slices"
 )
 
+func depth(value reflect.Value) (reflect.Type, int, bool, []int) {
+	i := 0
+	t := value.Type()
+
+	var di []int
+	mixed := isMixed(t)
+
+	for {
+		switch t.Kind() {
+		case reflect.Array:
+			di = append(di, t.Len())
+
+			i++
+			t = t.Elem()
+		case reflect.Slice:
+			if mixed {
+				di = append(di, 0)
+			} else {
+				di = append(di, value.Len())
+			}
+
+			i++
+			value = value.Index(0)
+			t = t.Elem()
+		default:
+			return t, i, mixed, di
+		}
+	}
+}
+

--- a/depth.go
+++ b/depth.go
@@ -18,3 +18,9 @@
  */
 
 package bin
+
+import (
+	"reflect"
+	"slices"
+)
+


### PR DESCRIPTION
This pull request adds a new utility called depth. It works by taking the absolute type of an array or slice, and depth size, arrays/slices sizes to build the new type upon unmarshalling.
It works as the order: depth, mixed, depth sizes* and type.
\* only for arrays as slices are parsed as normal (size first then data).