### PR TITLE
Benchmark

### DIFF
--- a/bin_test.go
+++ b/bin_test.go
@@ -198,3 +198,18 @@ func TestUnmarshal(t *testing.T) {
 		return
 	}
 }
+
+func BenchmarkEncode(b *testing.B) {
+	s := &stream{}
+
+	b.ResetTimer()
+	if err := NewEncoder(s).Encode(StructAllValue); err != nil {
+		b.Error("failed to encode (bench)")
+	}
+	b.StopTimer()
+
+	if string(s.Data) != string(expectedStructAll) {
+		b.Error("not equal (bench)")
+	}
+}
+

--- a/bin_test.go
+++ b/bin_test.go
@@ -213,3 +213,23 @@ func BenchmarkEncode(b *testing.B) {
 	}
 }
 
+func BenchmarkDecode(b *testing.B) {
+	s := &stream{
+		Data: expectedStructAll,
+	}
+
+	var i interface{}
+	_ = i
+	var sa *StructAll
+
+	b.ResetTimer()
+	if err := NewDecoder(s).Decode(&sa); err != nil {
+		b.Error("failed to decode (bench)")
+	}
+
+	b.StopTimer()
+
+	if !reflect.DeepEqual(sa, StructAllValue) {
+		b.Error("not equal (bench)")
+	}
+}


### PR DESCRIPTION
This pull request adds Benchmark for both encoding and decoding using `StructInterfaceAll` as the metric.