### PR TITLE
Fixed issue with `interface{}` multi depth and mixed slices and arrays.

### DIFF
--- a/bin_test.go
+++ b/bin_test.go
@@ -198,3 +198,38 @@ func TestUnmarshal(t *testing.T) {
 		return
 	}
 }
+
+func BenchmarkEncode(b *testing.B) {
+	s := &stream{}
+
+	b.ResetTimer()
+	if err := NewEncoder(s).Encode(StructAllValue); err != nil {
+		b.Error("failed to encode (bench)")
+	}
+	b.StopTimer()
+
+	if string(s.Data) != string(expectedStructAll) {
+		b.Error("not equal (bench)")
+	}
+}
+
+func BenchmarkDecode(b *testing.B) {
+	s := &stream{
+		Data: expectedStructAll,
+	}
+
+	var i interface{}
+	_ = i
+	var sa *StructAll
+
+	b.ResetTimer()
+	if err := NewDecoder(s).Decode(&sa); err != nil {
+		b.Error("failed to decode (bench)")
+	}
+
+	b.StopTimer()
+
+	if !reflect.DeepEqual(sa, StructAllValue) {
+		b.Error("not equal (bench)")
+	}
+}

--- a/bin_test.go
+++ b/bin_test.go
@@ -160,19 +160,19 @@ var (
 
 	expectedInterfaceNil           = append([]byte{byte(reflect.Invalid)}, expectedNil...)
 	expectedInterfaceBool          = append([]byte{byte(reflect.Bool)}, expectedBool...)
-	expectedInterfaceArray         = append([]byte{byte(reflect.Array), byte(reflect.Uint64), 3}, expectedArray...)
+	expectedInterfaceArray         = append([]byte{byte(reflect.Array), 1, 0, 3, byte(reflect.Uint64)}, expectedArray...)
 	expectedInterfaceMap           = append([]byte{byte(reflect.Map), byte(reflect.Uint8), byte(reflect.Int)}, expectedMap...)
 	expectedInterfaceMap2          = []byte{21, 20, 20, 1, 24, 6, 115, 116, 114, 105, 110, 103, 2, 10}
 	expectedInterfaceMap3          = []byte{21, 20, 24, 1, 2, 20, 6, 116, 119, 101, 110, 116, 121}
 	expectedInterfaceMap4          = []byte{21, 24, 20, 1, 5, 102, 105, 102, 116, 104, 2, 50}
-	expectedInterfaceSlice         = append([]byte{byte(reflect.Slice), byte(reflect.Int)}, expectedSlice...)
-	expectedInterfaceSlice2        = []byte{23, 20, 3, 24, 6, 116, 119, 101, 110, 116, 121, 2, 50, 24, 8, 104, 117, 110, 100, 114, 101, 100, 115}
+	expectedInterfaceSlice         = append([]byte{byte(reflect.Slice), 1, 0, byte(reflect.Int)}, expectedSlice...)
+	expectedInterfaceSlice2        = []byte{23, 1, 0, 20, 3, 24, 6, 116, 119, 101, 110, 116, 121, 2, 50, 24, 8, 104, 117, 110, 100, 114, 101, 100, 115}
 	expectedInterfaceString        = append([]byte{byte(reflect.String)}, expectedString...)
 	expectedInterfaceStruct        = []byte{25, 2, 100, 24, 3, 111, 110, 101, 200, 1, 11, 2}
 	expectedInterfaceStructNumbers = []byte{25, 14, 10, 2, 1, 20, 3, 2, 30, 4, 4, 40, 5, 8, 50, 6, 16, 60, 7, 32, 70, 8, 64, 80, 9, 128, 1, 90, 10, 128, 2, 100, 11, 128, 4, 110, 13, 138, 174, 143, 137, 4, 120, 14, 251, 168, 184, 189, 148, 220, 158, 154, 64, 130, 1, 15, 128, 128, 128, 145, 4, 128, 128, 128, 150, 4, 140, 1, 16, 128, 128, 128, 128, 128, 128, 144, 170, 64, 128, 128, 128, 128, 128, 128, 192, 171, 64}
-	expectedInterfaceStructArray   = []byte{25, 2, 10, 23, 2, 4, 3, 9, 27, 81, 20, 23, 20, 4, 24, 5, 72, 101, 108, 108, 111, 2, 13, 24, 5, 87, 111, 114, 108, 100, 24, 1, 33}
+	expectedInterfaceStructArray   = []byte{25, 2, 10, 23, 1, 0, 2, 4, 3, 9, 27, 81, 20, 23, 1, 0, 20, 4, 24, 5, 72, 101, 108, 108, 111, 2, 13, 24, 5, 87, 111, 114, 108, 100, 24, 1, 33}
 	expectedInterfaceStructMap     = []byte{25, 2, 10, 21, 8, 11, 1, 10, 128, 8, 20, 21, 20, 20, 1, 2, 81, 24, 4, 110, 105, 110, 101}
-	expectedInterfaceStructAll     = []byte{25, 4, 1, 25, 2, 100, 24, 3, 111, 110, 101, 200, 1, 11, 2, 2, 25, 14, 10, 2, 1, 20, 3, 2, 30, 4, 4, 40, 5, 8, 50, 6, 16, 60, 7, 32, 70, 8, 64, 80, 9, 128, 1, 90, 10, 128, 2, 100, 11, 128, 4, 110, 13, 138, 174, 143, 137, 4, 120, 14, 251, 168, 184, 189, 148, 220, 158, 154, 64, 130, 1, 15, 128, 128, 128, 145, 4, 128, 128, 128, 150, 4, 140, 1, 16, 128, 128, 128, 128, 128, 128, 144, 170, 64, 128, 128, 128, 128, 128, 128, 192, 171, 64, 3, 25, 2, 10, 23, 2, 4, 3, 9, 27, 81, 20, 23, 20, 4, 24, 5, 72, 101, 108, 108, 111, 2, 13, 24, 5, 87, 111, 114, 108, 100, 24, 1, 33, 4, 25, 2, 10, 21, 8, 11, 1, 10, 128, 8, 20, 21, 20, 20, 1, 2, 81, 24, 4, 110, 105, 110, 101}
+	expectedInterfaceStructAll     = []byte{25, 4, 1, 25, 2, 100, 24, 3, 111, 110, 101, 200, 1, 11, 2, 2, 25, 14, 10, 2, 1, 20, 3, 2, 30, 4, 4, 40, 5, 8, 50, 6, 16, 60, 7, 32, 70, 8, 64, 80, 9, 128, 1, 90, 10, 128, 2, 100, 11, 128, 4, 110, 13, 138, 174, 143, 137, 4, 120, 14, 251, 168, 184, 189, 148, 220, 158, 154, 64, 130, 1, 15, 128, 128, 128, 145, 4, 128, 128, 128, 150, 4, 140, 1, 16, 128, 128, 128, 128, 128, 128, 144, 170, 64, 128, 128, 128, 128, 128, 128, 192, 171, 64, 3, 25, 2, 10, 23, 1, 0, 2, 4, 3, 9, 27, 81, 20, 23, 1, 0, 20, 4, 24, 5, 72, 101, 108, 108, 111, 2, 13, 24, 5, 87, 111, 114, 108, 100, 24, 1, 33, 4, 25, 2, 10, 21, 8, 11, 1, 10, 128, 8, 20, 21, 20, 20, 1, 2, 81, 24, 4, 110, 105, 110, 101}
 )
 
 func TestMarshal(t *testing.T) {

--- a/depth.go
+++ b/depth.go
@@ -1,0 +1,88 @@
+/*
+ *     A tiny format for using binary data
+ *     Copyright (C) 2024  Dviih
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published
+ *     by the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package bin
+
+import (
+	"reflect"
+	"slices"
+)
+
+func depth(value reflect.Value) (reflect.Type, int, bool, []int) {
+	i := 0
+	t := value.Type()
+
+	var di []int
+	mixed := isMixed(t)
+
+	for {
+		switch t.Kind() {
+		case reflect.Array:
+			di = append(di, t.Len())
+
+			i++
+			t = t.Elem()
+		case reflect.Slice:
+			if mixed {
+				di = append(di, 0)
+			} else {
+				di = append(di, value.Len())
+			}
+
+			i++
+			value = value.Index(0)
+			t = t.Elem()
+		default:
+			return t, i, mixed, di
+		}
+	}
+}
+
+func isMixed(t reflect.Type) bool {
+	pt := t
+
+	for {
+		switch t.Elem().Kind() {
+		case reflect.Array, reflect.Slice:
+			if t.Elem().Kind() == pt.Kind() {
+				pt = t
+				t = t.Elem()
+				continue
+			}
+			return true
+		default:
+			return false
+		}
+	}
+}
+
+func fromDepth(t reflect.Type, d int, di []int) reflect.Type {
+	slices.Reverse(di)
+
+	for i := 0; i < d; i++ {
+		if di == nil || di[i] == 0 {
+			t = reflect.SliceOf(t)
+			continue
+		}
+
+		t = reflect.ArrayOf(di[i], t)
+	}
+
+	return t
+}


### PR DESCRIPTION
This pull request fixes issues with the arrays and slices that were parsed as `interface{}`, since they are indeed to have no type `bin` had a fault logic which couldn't handle more than a linear array.
#17 #18 Are the implementation and fix.
#19 as a bonus for benchmarking for bin.
Closes #16