### PR TITLE
Buffer

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -1,0 +1,26 @@
+/*
+ *     A tiny binary format
+ *     Copyright (C) 2024  Dviih
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published
+ *     by the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package buffer
+
+import (
+	"errors"
+	"io"
+)
+

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -106,3 +106,11 @@ func (buffer *Buffer) Len() int {
 	return len(buffer.data)
 }
 
+func (buffer *Buffer) Slice(start, end int) *Buffer {
+	return &Buffer{
+		data: buffer.data[start:end],
+		read: buffer.read - int64(start),
+		Max:  buffer.Max,
+	}
+}
+

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -50,3 +50,15 @@ func (buffer *Buffer) Write(data []byte) (int, error) {
 	return len(data), nil
 }
 
+func (buffer *Buffer) Read(data []byte) (int, error) {
+	n := copy(data, buffer.data[buffer.read:buffer.read+int64(len(data))])
+
+	buffer.read += int64(n)
+
+	if len(data) > n {
+		return n, io.EOF
+	}
+
+	return n, nil
+}
+

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -71,3 +71,30 @@ func (buffer *Buffer) ReadByte() (byte, error) {
 	return buffer.data[buffer.read-1], nil
 }
 
+func (buffer *Buffer) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	case io.SeekStart:
+		if buffer.read < offset {
+			return 0, InvalidOffset
+		}
+
+		buffer.read = offset
+	case io.SeekCurrent:
+		if buffer.read+offset > int64(len(buffer.data)) {
+			return 0, InvalidOffset
+		}
+
+		buffer.read += offset
+	case io.SeekEnd:
+		if buffer.read+offset > int64(len(buffer.data)) {
+			return 0, InvalidOffset
+		}
+
+		buffer.read = int64(len(buffer.data)) - offset
+	default:
+		return 0, InvalidWhence
+	}
+
+	return buffer.read, nil
+}
+

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -120,3 +120,9 @@ func New() *Buffer {
 	}
 }
 
+func From(data []byte) *Buffer {
+	return &Buffer{
+		data: data,
+		Max:  len(data),
+	}
+}

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -40,3 +40,13 @@ var (
 	InvalidWhence = errors.New("invalid whence")
 )
 
+func (buffer *Buffer) Write(data []byte) (int, error) {
+	if len(buffer.data)+len(data) > buffer.Max {
+		data = data[:buffer.Max-len(buffer.data)]
+	}
+
+	buffer.data = append(buffer.data, data...)
+
+	return len(data), nil
+}
+

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -28,6 +28,13 @@ const (
 	MaxSize = (1 << 31) - 1
 )
 
+type Buffer struct {
+	data []byte
+	read int64
+
+	Max int
+}
+
 var (
 	InvalidOffset = errors.New("invalid offset")
 	InvalidWhence = errors.New("invalid whence")

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -28,3 +28,8 @@ const (
 	MaxSize = (1 << 31) - 1
 )
 
+var (
+	InvalidOffset = errors.New("invalid offset")
+	InvalidWhence = errors.New("invalid whence")
+)
+

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -102,3 +102,7 @@ func (buffer *Buffer) Data() []byte {
 	return buffer.data[:]
 }
 
+func (buffer *Buffer) Len() int {
+	return len(buffer.data)
+}
+

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -114,3 +114,9 @@ func (buffer *Buffer) Slice(start, end int) *Buffer {
 	}
 }
 
+func New() *Buffer {
+	return &Buffer{
+		Max: MaxSize,
+	}
+}
+

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -62,3 +62,12 @@ func (buffer *Buffer) Read(data []byte) (int, error) {
 	return n, nil
 }
 
+func (buffer *Buffer) ReadByte() (byte, error) {
+	if buffer.read >= int64(len(buffer.data)) {
+		return 0, io.EOF
+	}
+
+	buffer.read++
+	return buffer.data[buffer.read-1], nil
+}
+

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -98,3 +98,7 @@ func (buffer *Buffer) Seek(offset int64, whence int) (int64, error) {
 	return buffer.read, nil
 }
 
+func (buffer *Buffer) Data() []byte {
+	return buffer.data[:]
+}
+

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -24,3 +24,7 @@ import (
 	"io"
 )
 
+const (
+	MaxSize = (1 << 31) - 1
+)
+


### PR DESCRIPTION
This pull request adds a _simplish_ buffer for bin to replace the massive `bytes` package.
It implements mainly `io.Writer`, `io.Reader` and `io.ByteReader` required for both encoder and decoder.
Methods like Len and Data are free to be used but not required for bin as how it is.
However `io.Seeker` is implemented and might be used.

There are two ways to create a buffer, one is by calling `New` and it will return a buffer instance, the other way is with `From` which acts as a replacement for `bytes.NewReader`.

Buffer will also be used to tests replacing `stream` (#24).