### PR TITLE
VarInt: Integer

### DIFF
--- a/varint.go
+++ b/varint.go
@@ -25,6 +25,9 @@ import (
 )
 
 func VarIntIn[T int | int8 | int16 | int32 | int64 | uint | uint8 | uint16 | uint32 | uint64](writer io.Writer, t T) error {
+type Integer = interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64
+}
 	if _, err := writer.Write(binary.AppendUvarint(nil, uint64(t))); err != nil {
 		return err
 	}

--- a/varint.go
+++ b/varint.go
@@ -24,10 +24,11 @@ import (
 	"io"
 )
 
-func VarIntIn[T int | int8 | int16 | int32 | int64 | uint | uint8 | uint16 | uint32 | uint64](writer io.Writer, t T) error {
 type Integer = interface {
 	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64
 }
+
+func VarIntIn[T Integer](writer io.Writer, t T) error {
 	if _, err := writer.Write(binary.AppendUvarint(nil, uint64(t))); err != nil {
 		return err
 	}

--- a/varint.go
+++ b/varint.go
@@ -36,7 +36,7 @@ func VarIntIn[T Integer](writer io.Writer, t T) error {
 	return nil
 }
 
-func VarIntOut[T int | int8 | int16 | int32 | int64 | uint | uint8 | uint16 | uint32 | uint64](reader io.ByteReader) (T, error) {
+func VarIntOut[T Integer](reader io.ByteReader) (T, error) {
 	t, err := binary.ReadUvarint(reader)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
This pull request is a tiny focused in a simpler approach with unions regarding generics with `VarIntIn` and `VarIntOut` since they are supposed to take any integer value in Go and return as the program wants.

The interface `Integer` is an union of all integer types also allowing any type which has them underlying.
For example `type MyInt = int` wouldn't be accepted previously although being an integer.

Both functions won't and must not accept float and complex generic types.