### PR TITLE
Enhanced As

### DIFF
--- a/struct.go
+++ b/struct.go
@@ -190,3 +190,33 @@ func (structs *Struct) Sub(i int, v interface{}) {
 
 	s.(*Struct).As(&v)
 }
+
+func As[T interface{}](v interface{}) T {
+	switch v := v.(type) {
+	case *Struct:
+		var t T
+
+		v.As(&t)
+		return t
+	case T:
+		return v
+	default:
+		value := Value(v)
+		t := reflect.TypeFor[T]()
+
+		var ptr reflect.Value
+
+		switch value.Kind() {
+		case reflect.Array, reflect.Slice:
+			ptr = as2(value, reflect.New(t).Elem())
+		case reflect.Map:
+			ptr = as2(value, reflect.MakeMapWithSize(t, value.Len()))
+		default:
+			var zero T
+			return zero
+		}
+
+		return ptr.Interface().(T)
+	}
+}
+


### PR DESCRIPTION
This pull request is about enhancement with `interface{}` as the previous method to call `As` was directly by casting which is unsafe. The new As method (`bin.As`) also allows the program to pass arrays, slices and maps with keys and elements having a struct.
The previous way to access `As` from `*Struct` is still available and used by `bin.As`.
Any call from this chain isn't supposed to panic so it's safe.