### PR TITLE
Decoder: Own `io.ByteReader` and `UnmarshalAs`

### DIFF
--- a/bin.go
+++ b/bin.go
@@ -126,3 +126,13 @@ func Unmarshal[T interface{}](data []byte) (T, error) {
 
 	return t, nil
 }
+
+func UnmarshalAs[T interface{}](data []byte) (T, error) {
+	i, err := Unmarshal[interface{}](data)
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+
+	return As[T](i), nil
+}

--- a/decoder.go
+++ b/decoder.go
@@ -31,10 +31,7 @@ type Decoder struct {
 }
 
 func (decoder *Decoder) ReadByte() (byte, error) {
-	data := make([]byte, 1)
-	_, err := decoder.reader.Read(data)
-
-	return data[0], err
+	return decoder.readByte()
 }
 
 func (decoder *Decoder) Decode(v interface{}) error {

--- a/decoder.go
+++ b/decoder.go
@@ -289,8 +289,23 @@ func (decoder *Decoder) structs(value reflect.Value) error {
 }
 
 func NewDecoder(reader io.Reader) *Decoder {
+	var byteReader func() (byte, error)
+
+	v, ok := reader.(io.ByteReader)
+	if ok {
+		byteReader = v.ReadByte
+	} else {
+		byteReader = func() (byte, error) {
+			data := make([]byte, 1)
+			_, err := reader.Read(data)
+
+			return data[0], err
+		}
+	}
+
 	return &Decoder{
-		reader: reader,
+		readByte: byteReader,
+		reader:   reader,
 	}
 }
 

--- a/decoder.go
+++ b/decoder.go
@@ -26,7 +26,8 @@ import (
 )
 
 type Decoder struct {
-	reader io.Reader
+	readByte func() (byte, error)
+	reader   io.Reader
 }
 
 func (decoder *Decoder) ReadByte() (byte, error) {


### PR DESCRIPTION
This pull request adds an optional implementation for `io.ByteReader` if passed `io.Reader` doesn't have one, it will achieve maximum performance for desired reader implementation.
The function `UnmarshalAs` is also added it will first call `Unmarshal` as `interface{}` then call `bin.As` to desired type T.

The Decoder structure will still keep the `ReadByte` method for compatibility and because VarInt requires it.