### PR TITLE
Structs and Types

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -20,7 +20,6 @@
 package bin
 
 import (
-	"errors"
 	"io"
 	"math"
 	"reflect"
@@ -228,13 +227,10 @@ func (decoder *Decoder) Decode(v interface{}) error {
 		return nil
 	case reflect.Struct:
 		fields := (&Struct{}).fields(value)
+
 		for i := 0; i < len(fields); i++ {
 			tag, err := VarIntOut[int](decoder)
 			if err != nil {
-				if errors.Is(err, io.EOF) {
-					continue
-				}
-
 				return err
 			}
 

--- a/decoder.go
+++ b/decoder.go
@@ -41,6 +41,12 @@ func (decoder *Decoder) Decode(v interface{}) error {
 		return CantSet
 	}
 
+	switch value.Type() {
+	case reflect.TypeFor[*Struct]():
+		Zero(value)
+		return decoder.structs(value)
+	}
+
 	if v == nil {
 		value.SetZero()
 		return nil

--- a/decoder.go
+++ b/decoder.go
@@ -20,6 +20,7 @@
 package bin
 
 import (
+	"errors"
 	"io"
 	"math"
 	"reflect"
@@ -227,10 +228,13 @@ func (decoder *Decoder) Decode(v interface{}) error {
 		return nil
 	case reflect.Struct:
 		fields := (&Struct{}).fields(value)
-
 		for i := 0; i < len(fields); i++ {
 			tag, err := VarIntOut[int](decoder)
 			if err != nil {
+				if errors.Is(err, io.EOF) {
+					continue
+				}
+
 				return err
 			}
 

--- a/decoder.go
+++ b/decoder.go
@@ -430,7 +430,7 @@ func (decoder *Decoder) getType() (reflect.Type, error) {
 
 		return reflect.MapOf(key, value), nil
 	case reflect.Struct:
-		return reflect.TypeFor[struct{}](), nil
+		return reflect.TypeFor[*Struct](), nil
 	case reflect.Chan, reflect.Func, reflect.Pointer, reflect.UnsafePointer:
 		return nil, nil
 	}

--- a/encoder.go
+++ b/encoder.go
@@ -207,8 +207,6 @@ func (encoder *Encoder) structs(value reflect.Value, kind bool) error {
 			return err
 		}
 
-		field := Abs[reflect.Value](value.Field(i))
-
 		if kind {
 			if err := encoder.Encode(Interface(field.Interface())); err != nil {
 				return err

--- a/encoder.go
+++ b/encoder.go
@@ -288,7 +288,15 @@ func (encoder *Encoder) getType(value reflect.Value) error {
 
 		return nil
 	case reflect.Struct:
-		if err := encoder.Encode(value.Type().NumField()); err != nil {
+		n := value.Type().NumField()
+
+		for i := 0; i < value.Type().NumField(); i++ {
+			if value.Field(i).IsZero() {
+				n--
+			}
+		}
+
+		if err := encoder.Encode(n); err != nil {
 			return nil
 		}
 

--- a/encoder.go
+++ b/encoder.go
@@ -103,7 +103,7 @@ func (encoder *Encoder) Encode(v interface{}) error {
 
 		value = Abs[reflect.Value](value)
 
-		if err := encoder.Encode(value.Kind()); err != nil {
+		if err := encoder.getType(value); err != nil {
 			return err
 		}
 
@@ -265,11 +265,11 @@ func (encoder *Encoder) getType(value reflect.Value) error {
 
 		return nil
 	case reflect.Map:
-		if err := encoder.Encode(value.Type().Key().Kind()); err != nil {
+		if err := encoder.getType(reflect.New(value.Type().Key()).Elem()); err != nil {
 			return err
 		}
 
-		if err := encoder.Encode(value.Type().Elem().Kind()); err != nil {
+		if err := encoder.getType(reflect.New(value.Type().Elem()).Elem()); err != nil {
 			return err
 		}
 

--- a/encoder.go
+++ b/encoder.go
@@ -177,6 +177,11 @@ func (encoder *Encoder) structs(value reflect.Value, kind bool) error {
 	t := value.Type()
 
 	for i := 0; i < value.NumField(); i++ {
+		field := Abs[reflect.Value](value.Field(i))
+		if field.IsZero() {
+			continue
+		}
+
 		fieldType := t.Field(i)
 
 		if !fieldType.IsExported() {

--- a/encoder.go
+++ b/encoder.go
@@ -226,6 +226,10 @@ func (encoder *Encoder) structs(value reflect.Value, kind bool) error {
 }
 
 func (encoder *Encoder) getType(value reflect.Value) error {
+	if err := encoder.Encode(value.Type().Kind()); err != nil {
+		return err
+	}
+
 	switch value.Type().Kind() {
 	case reflect.Array:
 		dt, d, mixed, di := depth(value)

--- a/encoder.go
+++ b/encoder.go
@@ -109,14 +109,18 @@ func (encoder *Encoder) Encode(v interface{}) error {
 
 		switch value.Kind() {
 		case reflect.Array, reflect.Slice, reflect.Map:
-			if err := encoder.getType(value); err != nil {
-				return err
+			switch value.Type().Elem().Kind() {
+			case reflect.Struct:
+				for i := 0; i < value.Len(); i++ {
+					if err := encoder.Encode(_interface(value.Index(i))); err != nil {
+						return err
+					}
+				}
+
+				return nil
+			default:
 			}
 		case reflect.Struct:
-			if err := encoder.getType(value); err != nil {
-				return err
-			}
-
 			return encoder.structs(value, true)
 		default:
 		}


### PR DESCRIPTION
The pull request in Decoder changes `reflect.Struct` understand from `struct{}` to `*Struct` being easier to do stuff.
The pull request in Encoder changes places where `getType` should be used instead of appending the kind and in places where structures requires special treatment (all for `interface{}` related stuff).
Also Encoder will check for zero fields in a structure and not add when encoding thus lowering the size of fields.