### PR TITLE
Replace test's stream with bin's buffer

### DIFF
--- a/bin_test.go
+++ b/bin_test.go
@@ -200,31 +200,22 @@ func TestUnmarshal(t *testing.T) {
 }
 
 func BenchmarkEncode(b *testing.B) {
-	s := &stream{}
-
-	b.ResetTimer()
-	if err := NewEncoder(s).Encode(StructAllValue); err != nil {
+	data, err := Marshal(StructAllValue)
+	if err != nil {
 		b.Error("failed to encode (bench)")
 	}
+
 	b.StopTimer()
 
-	if string(s.Data) != string(expectedStructAll) {
+	if string(data) != string(expectedStructAll) {
 		b.Error("not equal (bench)")
 	}
 }
 
 func BenchmarkDecode(b *testing.B) {
-	s := &stream{
-		Data: expectedStructAll,
-	}
-
-	var i interface{}
-	_ = i
-	var sa *StructAll
-
-	b.ResetTimer()
-	if err := NewDecoder(s).Decode(&sa); err != nil {
-		b.Error("failed to decode (bench)")
+	sa, err := Unmarshal[*StructAll](expectedStructAll)
+	if err != nil {
+		b.Errorf("failed to unmarshalas (bench): %v", err)
 	}
 
 	b.StopTimer()

--- a/bin_test.go
+++ b/bin_test.go
@@ -24,23 +24,6 @@ import (
 	"testing"
 )
 
-type stream struct {
-	Data []byte
-	read int
-}
-
-func (stream *stream) Write(data []byte) (int, error) {
-	stream.Data = append(stream.Data, data...)
-	return len(data), nil
-}
-
-func (stream *stream) Read(data []byte) (int, error) {
-	i := copy(data, stream.Data[stream.read:stream.read+len(data)])
-	stream.read += len(data)
-
-	return i, nil
-}
-
 type Struct1 struct {
 	FieldOne string `bin:"100"`
 	FieldTwo uint64 `bin:"200"`

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -20,6 +20,7 @@
 package bin
 
 import (
+	"github.com/Dviih/bin/buffer"
 	"reflect"
 	"testing"
 )
@@ -27,11 +28,7 @@ import (
 func TestDecoderNil(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedNil,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedNil))
 
 	var i interface{}
 	if err := decoder.Decode(&i); err != nil {
@@ -46,11 +43,7 @@ func TestDecoderNil(t *testing.T) {
 func TestDecoderBool(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedBool,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedBool))
 
 	var b bool
 	if err := decoder.Decode(&b); err != nil {
@@ -65,11 +58,7 @@ func TestDecoderBool(t *testing.T) {
 func TestDecoderInt(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedInt,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedInt))
 
 	var i int
 	if err := decoder.Decode(&i); err != nil {
@@ -84,11 +73,7 @@ func TestDecoderInt(t *testing.T) {
 func TestDecoderUint(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedUint,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedUint))
 
 	var u uint
 	if err := decoder.Decode(&u); err != nil {
@@ -103,11 +88,7 @@ func TestDecoderUint(t *testing.T) {
 func TestDecoderFloat(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedFloat,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedFloat))
 
 	var f float64
 	if err := decoder.Decode(&f); err != nil {
@@ -122,11 +103,7 @@ func TestDecoderFloat(t *testing.T) {
 func TestDecoderComplex(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedComplex,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedComplex))
 
 	var c complex128
 	if err := decoder.Decode(&c); err != nil {
@@ -141,11 +118,7 @@ func TestDecoderComplex(t *testing.T) {
 func TestDecoderArray(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedArray,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedArray))
 
 	var array [3]uint64
 	if err := decoder.Decode(&array); err != nil {
@@ -160,11 +133,7 @@ func TestDecoderArray(t *testing.T) {
 func TestDecoderMap(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedMap,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedMap))
 
 	var m map[byte]int
 	if err := decoder.Decode(&m); err != nil {
@@ -179,11 +148,7 @@ func TestDecoderMap(t *testing.T) {
 func TestDecoderSlice(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedSlice,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedSlice))
 
 	var slice []int
 	if err := decoder.Decode(&slice); err != nil {
@@ -198,11 +163,7 @@ func TestDecoderSlice(t *testing.T) {
 func TestDecoderString(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedString,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedString))
 
 	var _string string
 	if err := decoder.Decode(&_string); err != nil {
@@ -217,11 +178,7 @@ func TestDecoderString(t *testing.T) {
 func TestDecoderStruct(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedStruct,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedStruct))
 
 	var struct2 *Struct1
 	if err := decoder.Decode(&struct2); err != nil {
@@ -236,11 +193,7 @@ func TestDecoderStruct(t *testing.T) {
 func TestDecoderStructNumbers(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedStructNumbers,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedStructNumbers))
 
 	var structNumbers *StructNumbers
 	if err := decoder.Decode(&structNumbers); err != nil {
@@ -255,11 +208,7 @@ func TestDecoderStructNumbers(t *testing.T) {
 func TestDecoderStructArray(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedStructArray,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedStructArray))
 
 	var structArray *StructArray
 	if err := decoder.Decode(&structArray); err != nil {
@@ -274,11 +223,7 @@ func TestDecoderStructArray(t *testing.T) {
 func TestDecoderStructMap(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedStructMap,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedStructMap))
 
 	var structMap *StructMap
 	if err := decoder.Decode(&structMap); err != nil {
@@ -293,11 +238,7 @@ func TestDecoderStructMap(t *testing.T) {
 func TestDecoderStructAll(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedStructAll,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedStructAll))
 
 	var structAll *StructAll
 	if err := decoder.Decode(&structAll); err != nil {
@@ -312,11 +253,7 @@ func TestDecoderStructAll(t *testing.T) {
 func TestDecoderInterfaceNil(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedNil,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedInterfaceNil))
 
 	ptr := reflect.New(reflect.TypeFor[interface{}]()).Elem()
 	if err := decoder.Decode(ptr); err != nil {
@@ -331,11 +268,7 @@ func TestDecoderInterfaceNil(t *testing.T) {
 func TestDecoderInterfaceBool(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedInterfaceBool,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedInterfaceBool))
 
 	var i interface{}
 	if err := decoder.Decode(&i); err != nil {
@@ -350,11 +283,7 @@ func TestDecoderInterfaceBool(t *testing.T) {
 func TestDecoderInterfaceArray(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedInterfaceArray,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedInterfaceArray))
 
 	var i interface{}
 	if err := decoder.Decode(&i); err != nil {
@@ -369,11 +298,7 @@ func TestDecoderInterfaceArray(t *testing.T) {
 func TestDecoderInterfaceMap(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedInterfaceMap,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedInterfaceMap))
 
 	var i interface{}
 	if err := decoder.Decode(&i); err != nil {
@@ -388,11 +313,7 @@ func TestDecoderInterfaceMap(t *testing.T) {
 func TestDecoderInterfaceMap2(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedInterfaceMap2,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedInterfaceMap2))
 
 	var i interface{}
 	if err := decoder.Decode(&i); err != nil {
@@ -407,11 +328,7 @@ func TestDecoderInterfaceMap2(t *testing.T) {
 func TestDecoderInterfaceMap3(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedInterfaceMap3,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedInterfaceMap3))
 
 	var i interface{}
 	if err := decoder.Decode(&i); err != nil {
@@ -426,11 +343,7 @@ func TestDecoderInterfaceMap3(t *testing.T) {
 func TestDecoderInterfaceMap4(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedInterfaceMap4,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedInterfaceMap4))
 
 	var i interface{}
 	if err := decoder.Decode(&i); err != nil {
@@ -445,11 +358,7 @@ func TestDecoderInterfaceMap4(t *testing.T) {
 func TestDecoderInterfaceSlice(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedInterfaceSlice,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedInterfaceSlice))
 
 	var i interface{}
 	if err := decoder.Decode(&i); err != nil {
@@ -464,11 +373,7 @@ func TestDecoderInterfaceSlice(t *testing.T) {
 func TestDecoderInterfaceSlice2(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedInterfaceSlice2,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedInterfaceSlice2))
 
 	var i interface{}
 	if err := decoder.Decode(&i); err != nil {
@@ -483,11 +388,7 @@ func TestDecoderInterfaceSlice2(t *testing.T) {
 func TestDecoderInterfaceString(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedInterfaceString,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedInterfaceString))
 
 	var i interface{}
 	if err := decoder.Decode(&i); err != nil {
@@ -502,19 +403,14 @@ func TestDecoderInterfaceString(t *testing.T) {
 func TestDecoderInterfaceStruct(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedInterfaceStruct,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedInterfaceStruct))
 
 	var i interface{}
 	if err := decoder.Decode(&i); err != nil {
 		t.Error("failed to decode struct")
 	}
 
-	var st *Struct1
-	i.(*Struct).As(&st)
+	st := As[*Struct1](i)
 
 	if !reflect.DeepEqual(st, Struct2) {
 		t.Errorf("expected %v, received: %v", Struct2, st)
@@ -524,11 +420,7 @@ func TestDecoderInterfaceStruct(t *testing.T) {
 func TestDecoderInterfaceStructNumbers(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedInterfaceStructNumbers,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedInterfaceStructNumbers))
 
 	var i interface{}
 	if err := decoder.Decode(&i); err != nil {
@@ -546,11 +438,7 @@ func TestDecoderInterfaceStructNumbers(t *testing.T) {
 func TestDecoderInterfaceStructArray(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedInterfaceStructArray,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedInterfaceStructArray))
 
 	var i interface{}
 	if err := decoder.Decode(&i); err != nil {
@@ -568,11 +456,7 @@ func TestDecoderInterfaceStructArray(t *testing.T) {
 func TestDecoderInterfaceStructMap(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedInterfaceStructMap,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedInterfaceStructMap))
 
 	var i interface{}
 	if err := decoder.Decode(&i); err != nil {
@@ -590,19 +474,14 @@ func TestDecoderInterfaceStructMap(t *testing.T) {
 func TestDecoderInterfaceStructAll(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{
-		Data: expectedInterfaceStructAll,
-	}
-
-	decoder := NewDecoder(s)
+	decoder := NewDecoder(buffer.From(expectedInterfaceStructAll))
 
 	var i interface{}
 	if err := decoder.Decode(&i); err != nil {
 		t.Error("failed to decode struct all")
 	}
 
-	var st *StructAll
-	i.(*Struct).As(&st)
+	st := As[*StructAll](i)
 
 	if !reflect.DeepEqual(st, StructAllValue) {
 		t.Errorf("expected %v, received: %v", StructAllValue, st)

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -20,291 +20,292 @@
 package bin
 
 import (
+	"github.com/Dviih/bin/buffer"
 	"testing"
 )
 
 func TestEncoderNil(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Nil); err != nil {
 		t.Error("failed to encode nil")
 	}
 
-	if string(s.Data) != string(expectedNil) {
-		t.Errorf("expected %v, received: %v", expectedNil, s.Data)
+	if string(b.Data()) != string(expectedNil) {
+		t.Errorf("expected %v, received: %v", expectedNil, b.Data())
 	}
 }
 
 func TestEncoderBool(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Bool); err != nil {
 		t.Error("failed to encode boolean")
 	}
 
-	if string(s.Data) != string(expectedBool) {
-		t.Errorf("expected %v, received: %v", expectedBool, s.Data)
+	if string(b.Data()) != string(expectedBool) {
+		t.Errorf("expected %v, received: %v", expectedBool, b.Data())
 	}
 }
 
 func TestEncoderInt(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Int); err != nil {
 		t.Error("failed to encode int")
 	}
 
-	if string(s.Data) != string(expectedInt) {
-		t.Errorf("expected %v, received: %v", expectedInt, s.Data)
+	if string(b.Data()) != string(expectedInt) {
+		t.Errorf("expected %v, received: %v", expectedInt, b.Data())
 	}
 }
 
 func TestEncoderUint(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Uint); err != nil {
 		t.Error("failed to encode uint")
 	}
 
-	if string(s.Data) != string(expectedUint) {
-		t.Errorf("expected %v, received: %v", expectedUint, s.Data)
+	if string(b.Data()) != string(expectedUint) {
+		t.Errorf("expected %v, received: %v", expectedUint, b.Data())
 	}
 }
 
 func TestEncoderFloat(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Float); err != nil {
 		t.Error("failed to encode float")
 	}
 
-	if string(s.Data) != string(expectedFloat) {
-		t.Errorf("expected %v, received: %v", expectedFloat, s.Data)
+	if string(b.Data()) != string(expectedFloat) {
+		t.Errorf("expected %v, received: %v", expectedFloat, b.Data())
 	}
 }
 
 func TestEncoderComplex(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Complex); err != nil {
 		t.Error("failed to encode complex")
 	}
 
-	if string(s.Data) != string(expectedComplex) {
-		t.Errorf("expected %v, received: %v", expectedComplex, s.Data)
+	if string(b.Data()) != string(expectedComplex) {
+		t.Errorf("expected %v, received: %v", expectedComplex, b.Data())
 	}
 }
 
 func TestEncoderArray(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Array); err != nil {
 		t.Error("failed to encode array")
 	}
 
-	if string(s.Data) != string(expectedArray) {
-		t.Errorf("expected %v, received: %v", expectedArray, s.Data)
+	if string(b.Data()) != string(expectedArray) {
+		t.Errorf("expected %v, received: %v", expectedArray, b.Data())
 	}
 }
 
 func TestEncoderMap(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Map); err != nil {
 		t.Error("failed to encode map")
 	}
 
-	if string(s.Data) != string(expectedMap) {
-		t.Errorf("expected %v, received: %v", expectedMap, s.Data)
+	if string(b.Data()) != string(expectedMap) {
+		t.Errorf("expected %v, received: %v", expectedMap, b.Data())
 	}
 }
 
 func TestEncoderSlice(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Slice); err != nil {
 		t.Error("failed to encode slice")
 	}
 
-	if string(s.Data) != string(expectedSlice) {
-		t.Errorf("expected %v, received: %v", expectedSlice, s.Data)
+	if string(b.Data()) != string(expectedSlice) {
+		t.Errorf("expected %v, received: %v", expectedSlice, b.Data())
 	}
 }
 
 func TestEncoderString(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(String); err != nil {
 		t.Error("failed to encode string")
 	}
 
-	if string(s.Data) != string(expectedString) {
-		t.Errorf("expected %v, received: %v", expectedString, s.Data)
+	if string(b.Data()) != string(expectedString) {
+		t.Errorf("expected %v, received: %v", expectedString, b.Data())
 	}
 }
 
 func TestEncoderStruct(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Struct2); err != nil {
 		t.Error("failed to encode struct")
 	}
 
-	if string(s.Data) != string(expectedStruct) {
-		t.Errorf("expected %v, received: %v", expectedStruct, s.Data)
+	if string(b.Data()) != string(expectedStruct) {
+		t.Errorf("expected %v, received: %v", expectedStruct, b.Data())
 	}
 }
 
 func TestEncoderStructNumbers(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(StructNumbersValue); err != nil {
 		t.Error("failed to encode struct numbers")
 	}
 
-	if string(s.Data) != string(expectedStructNumbers) {
-		t.Errorf("expected %v, received: %v", expectedStructNumbers, s.Data)
+	if string(b.Data()) != string(expectedStructNumbers) {
+		t.Errorf("expected %v, received: %v", expectedStructNumbers, b.Data())
 	}
 }
 
 func TestEncoderStructArray(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(StructArrayValue); err != nil {
 		t.Error("failed to encode struct array")
 	}
 
-	if string(s.Data) != string(expectedStructArray) {
-		t.Errorf("expected %v, received: %v", expectedStructArray, s.Data)
+	if string(b.Data()) != string(expectedStructArray) {
+		t.Errorf("expected %v, received: %v", expectedStructArray, b.Data())
 	}
 }
 
 func TestEncoderStructMap(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(StructMapValue); err != nil {
 		t.Error("failed to encode struct map")
 	}
 
-	if string(s.Data) != string(expectedStructMap) {
-		t.Errorf("expected %v, received: %v", expectedStructMap, s.Data)
+	if string(b.Data()) != string(expectedStructMap) {
+		t.Errorf("expected %v, received: %v", expectedStructMap, b.Data())
 	}
 }
 
 func TestEncoderStructAll(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(StructAllValue); err != nil {
 		t.Error("failed to encode struct all")
 	}
 
-	if string(s.Data) != string(expectedStructAll) {
-		t.Errorf("expected %v, received: %v", expectedStructAll, s.Data)
+	if string(b.Data()) != string(expectedStructAll) {
+		t.Errorf("expected %v, received: %v", expectedStructAll, b.Data())
 	}
 }
 
 func TestEncoderInterfaceNil(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Interface(nil)); err != nil {
 		t.Errorf("failed to encode interface nil")
 	}
 
-	if string(s.Data) != string(expectedInterfaceNil) {
-		t.Errorf("expected: %v, received: %v", expectedInterfaceNil, s.Data)
+	if string(b.Data()) != string(expectedInterfaceNil) {
+		t.Errorf("expected: %v, received: %v", expectedInterfaceNil, b.Data())
 	}
 }
 
 func TestEncoderInterfaceBool(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Interface(Bool)); err != nil {
 		t.Errorf("failed to encode interface boolean")
 	}
 
-	if string(s.Data) != string(expectedInterfaceBool) {
-		t.Errorf("expected: %v, received: %v", expectedInterfaceBool, s.Data)
+	if string(b.Data()) != string(expectedInterfaceBool) {
+		t.Errorf("expected: %v, received: %v", expectedInterfaceBool, b.Data())
 	}
 }
 
 func TestEncoderInterfaceArray(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Interface(Array)); err != nil {
 		t.Errorf("failed to encode interface array")
 	}
 
-	if string(s.Data) != string(expectedInterfaceArray) {
-		t.Errorf("expected: %v, received: %v", expectedInterfaceArray, s.Data)
+	if string(b.Data()) != string(expectedInterfaceArray) {
+		t.Errorf("expected: %v, received: %v", expectedInterfaceArray, b.Data())
 	}
 }
 
 func TestEncoderInterfaceMap(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Interface(Map)); err != nil {
 		t.Errorf("failed to encode interface map")
 	}
 
-	if string(s.Data) != string(expectedInterfaceMap) {
-		t.Errorf("expected: %v, received: %v", expectedInterfaceMap, s.Data)
+	if string(b.Data()) != string(expectedInterfaceMap) {
+		t.Errorf("expected: %v, received: %v", expectedInterfaceMap, b.Data())
 	}
 }
 
@@ -312,15 +313,15 @@ func TestEncoderInterfaceMap(t *testing.T) {
 func TestEncoderInterfaceMap2(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Interface(Map2)); err != nil {
 		t.Errorf("failed to encode interface map2")
 	}
 
-	if string(s.Data) != string(expectedInterfaceMap2) {
-		t.Errorf("expected: %v, received: %v", expectedInterfaceMap2, s.Data)
+	if string(b.Data()) != string(expectedInterfaceMap2) {
+		t.Errorf("expected: %v, received: %v", expectedInterfaceMap2, b.Data())
 	}
 }
 
@@ -328,15 +329,15 @@ func TestEncoderInterfaceMap2(t *testing.T) {
 func TestEncoderInterfaceMap3(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Interface(Map3)); err != nil {
 		t.Errorf("failed to encode interface map3")
 	}
 
-	if string(s.Data) != string(expectedInterfaceMap3) {
-		t.Errorf("expected: %v, received: %v", expectedInterfaceMap3, s.Data)
+	if string(b.Data()) != string(expectedInterfaceMap3) {
+		t.Errorf("expected: %v, received: %v", expectedInterfaceMap3, b.Data())
 	}
 }
 
@@ -344,133 +345,133 @@ func TestEncoderInterfaceMap3(t *testing.T) {
 func TestEncoderInterfaceMap4(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Interface(Map4)); err != nil {
 		t.Errorf("failed to encode interface map4")
 	}
 
-	if string(s.Data) != string(expectedInterfaceMap4) {
-		t.Errorf("expected: %v, received: %v", expectedInterfaceMap4, s.Data)
+	if string(b.Data()) != string(expectedInterfaceMap4) {
+		t.Errorf("expected: %v, received: %v", expectedInterfaceMap4, b.Data())
 	}
 }
 
 func TestEncoderInterfaceSlice(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Interface(Slice)); err != nil {
 		t.Errorf("failed to encode interface slice")
 	}
 
-	if string(s.Data) != string(expectedInterfaceSlice) {
-		t.Errorf("expected: %v, received: %v", expectedInterfaceSlice, s.Data)
+	if string(b.Data()) != string(expectedInterfaceSlice) {
+		t.Errorf("expected: %v, received: %v", expectedInterfaceSlice, b.Data())
 	}
 }
 
 func TestEncoderInterfaceSlice2(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Interface(Slice2)); err != nil {
 		t.Errorf("failed to encode interface slice2")
 	}
 
-	if string(s.Data) != string(expectedInterfaceSlice2) {
-		t.Errorf("expected: %v, received: %v", expectedInterfaceSlice2, s.Data)
+	if string(b.Data()) != string(expectedInterfaceSlice2) {
+		t.Errorf("expected: %v, received: %v", expectedInterfaceSlice2, b.Data())
 	}
 }
 
 func TestEncoderInterfaceString(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Interface(String)); err != nil {
 		t.Errorf("failed to encode interface string")
 	}
 
-	if string(s.Data) != string(expectedInterfaceString) {
-		t.Errorf("expected: %v, received: %v", expectedInterfaceString, s.Data)
+	if string(b.Data()) != string(expectedInterfaceString) {
+		t.Errorf("expected: %v, received: %v", expectedInterfaceString, b.Data())
 	}
 }
 
 func TestEncoderInterfaceStruct(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Interface(Struct2)); err != nil {
 		t.Errorf("failed to encode interface struct")
 	}
 
-	if string(s.Data) != string(expectedInterfaceStruct) {
-		t.Errorf("expected: %v, received: %v", expectedInterfaceStruct, s.Data)
+	if string(b.Data()) != string(expectedInterfaceStruct) {
+		t.Errorf("expected: %v, received: %v", expectedInterfaceStruct, b.Data())
 	}
 }
 
 func TestEncoderInterfaceStructNumbers(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Interface(StructNumbersValue)); err != nil {
 		t.Errorf("failed to encode interface struct numbers")
 	}
 
-	if string(s.Data) != string(expectedInterfaceStructNumbers) {
-		t.Errorf("expected: %v, received: %v", expectedInterfaceStructNumbers, s.Data)
+	if string(b.Data()) != string(expectedInterfaceStructNumbers) {
+		t.Errorf("expected: %v, received: %v", expectedInterfaceStructNumbers, b.Data())
 	}
 }
 
 func TestEncoderInterfaceStructArray(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Interface(StructArrayValue)); err != nil {
 		t.Errorf("failed to encode interface struct array")
 	}
 
-	if string(s.Data) != string(expectedInterfaceStructArray) {
-		t.Errorf("expected: %v, received: %v", expectedInterfaceStructArray, s.Data)
+	if string(b.Data()) != string(expectedInterfaceStructArray) {
+		t.Errorf("expected: %v, received: %v", expectedInterfaceStructArray, b.Data())
 	}
 }
 func TestEncoderInterfaceStructMap(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Interface(StructMapValue)); err != nil {
 		t.Errorf("failed to encode interface struct map")
 	}
 
-	if string(s.Data) != string(expectedInterfaceStructMap) {
-		t.Errorf("expected: %v, received: %v", expectedInterfaceStructMap, s.Data)
+	if string(b.Data()) != string(expectedInterfaceStructMap) {
+		t.Errorf("expected: %v, received: %v", expectedInterfaceStructMap, b.Data())
 	}
 }
 
 func TestEncoderInterfaceStructAll(t *testing.T) {
 	t.Parallel()
 
-	s := &stream{}
-	encoder := NewEncoder(s)
+	b := buffer.New()
+	encoder := NewEncoder(b)
 
 	if err := encoder.Encode(Interface(StructAllValue)); err != nil {
 		t.Errorf("failed to encode interface struct all")
 	}
 
-	if string(s.Data) != string(expectedInterfaceStructAll) {
-		t.Errorf("expected: %v, received: %v", expectedInterfaceStructAll, s.Data)
+	if string(b.Data()) != string(expectedInterfaceStructAll) {
+		t.Errorf("expected: %v, received: %v", expectedInterfaceStructAll, b.Data())
 	}
 }


### PR DESCRIPTION
This pull request replaces test's stream (`bin_test.go`) to bin's buffer.