### PR TITLE
Missing f at `README.md` for linking `protocol_inter**f**ace.md`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@
 ## Protocol specification
 
 ### [Bin Protocol](https://github.com/Dviih/bin/blob/main/protocol.md)
-### [Interface Extension](https://github.com/Dviih/bin/blob/main/protocol_interace.md)
+### [Interface Extension](https://github.com/Dviih/bin/blob/main/protocol_interface.md)
 
 ---
 


### PR DESCRIPTION
A `f` is missing for the link.