### PR TITLE
Struct interface field might as well behave as an interface.

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -188,6 +188,11 @@ func (encoder *Encoder) structs(value reflect.Value, kind bool) error {
 			continue
 		}
 
+		kind := kind
+		if !kind && fieldType.Type.Kind() == reflect.Interface {
+			kind = true
+		}
+
 		tag := i + 1
 
 		if lookup, ok := fieldType.Tag.Lookup("bin"); ok {


### PR DESCRIPTION
This is a simple patch to make `interface{}` struct fields usable as they've been broken. The patch is simple and uses the same architecture as `interfaces`.
By adding a kind checker for field type it's possible to check whether field is interface or not.