### PR TITLE
Patch more nested

### DIFF
--- a/bin.go
+++ b/bin.go
@@ -1,6 +1,6 @@
 /*
  *     A tiny binary format
- *     Copyright (C) 2024  Dviih
+ *     Copyright (C) 2025  Dviih
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Affero General Public License as published
@@ -26,9 +26,10 @@ import (
 )
 
 var (
-	Invalid             = errors.New("invalid value")
-	CantSet             = errors.New("can't set")
-	unexpectedBehaviour = errors.New("this is a very unexpected behaviour")
+	Invalid              = errors.New("invalid value")
+	CantSet              = errors.New("can't set")
+	TypeMustBeComparable = errors.New("type must be comparable")
+	unexpectedBehaviour  = errors.New("this is a very unexpected behaviour")
 )
 
 func Value(v interface{}) reflect.Value {

--- a/decoder.go
+++ b/decoder.go
@@ -1,6 +1,6 @@
 /*
  *     A tiny binary format
- *     Copyright (C) 2024  Dviih
+ *     Copyright (C) 2025  Dviih
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Affero General Public License as published

--- a/encoder.go
+++ b/encoder.go
@@ -103,14 +103,20 @@ func (encoder *Encoder) Encode(v interface{}) error {
 
 		value = Abs[reflect.Value](value)
 
-		if err := encoder.getType(value); err != nil {
-			return err
-		}
-
 		switch value.Kind() {
-		case reflect.Array, reflect.Slice, reflect.Map:
-			switch value.Type().Elem().Kind() {
+		case reflect.Array, reflect.Slice:
+			_, elem := KeyElem(value)
+
+			switch Abs[reflect.Type](elem).Kind() {
 			case reflect.Struct:
+				if err := encoder.getType(reflect.New(reflect.TypeFor[[]interface{}]()).Elem()); err != nil {
+					return err
+				}
+
+				if err := encoder.Encode(value.Len()); err != nil {
+					return err
+				}
+
 				for i := 0; i < value.Len(); i++ {
 					if err := encoder.Encode(interfaces(value.Index(i))); err != nil {
 						return err

--- a/encoder.go
+++ b/encoder.go
@@ -179,6 +179,10 @@ func (encoder *Encoder) Encode(v interface{}) error {
 
 		return encoder.Encode(value)
 	case reflect.Map:
+		if !value.Type().Key().Comparable() {
+			return TypeMustBeComparable
+		}
+
 		if err := encoder.Encode(value.Len()); err != nil {
 			return err
 		}

--- a/encoder.go
+++ b/encoder.go
@@ -164,9 +164,17 @@ func (encoder *Encoder) Encode(v interface{}) error {
 					return err
 				}
 			}
+
 		case reflect.Struct:
+			if err := encoder.getType(value); err != nil {
+				return err
+			}
+
 			return encoder.structs(value, true)
 		default:
+			if err := encoder.getType(value); err != nil {
+				return err
+			}
 		}
 
 		return encoder.Encode(value)

--- a/encoder.go
+++ b/encoder.go
@@ -1,6 +1,6 @@
 /*
  *     A tiny binary format
- *     Copyright (C) 2024  Dviih
+ *     Copyright (C) 2025  Dviih
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Affero General Public License as published

--- a/encoder.go
+++ b/encoder.go
@@ -234,7 +234,7 @@ func (encoder *Encoder) structs(value reflect.Value, kind bool) error {
 
 	for i := 0; i < value.NumField(); i++ {
 		field := Abs[reflect.Value](value.Field(i))
-		if field.IsZero() {
+		if field.IsZero() && kind {
 			continue
 		}
 
@@ -261,6 +261,19 @@ func (encoder *Encoder) structs(value reflect.Value, kind bool) error {
 
 		if err := encoder.Encode(tag); err != nil {
 			return err
+		}
+
+		kind := kind
+		if field.Kind() == reflect.Struct {
+			kind = true
+		}
+
+		if field.IsZero() {
+			if err := encoder.Encode(0); err != nil {
+				return err
+			}
+
+			continue
 		}
 
 		if kind {

--- a/encoder.go
+++ b/encoder.go
@@ -125,6 +125,17 @@ func (encoder *Encoder) Encode(v interface{}) error {
 
 				return nil
 			default:
+				if err := encoder.getType(value); err != nil {
+					return err
+				}
+			}
+		case reflect.Map:
+			key, elem := KeyElem(value)
+
+			if !key.Comparable() {
+				return TypeMustBeComparable
+			}
+
 			}
 		case reflect.Struct:
 			return encoder.structs(value, true)

--- a/encoder.go
+++ b/encoder.go
@@ -136,6 +136,33 @@ func (encoder *Encoder) Encode(v interface{}) error {
 				return TypeMustBeComparable
 			}
 
+			switch Abs[reflect.Type](elem).Kind() {
+			case reflect.Struct:
+				if err := encoder.getType(reflect.New(reflect.MapOf(key, reflect.TypeFor[interface{}]())).Elem()); err != nil {
+					return err
+				}
+
+				if err := encoder.Encode(value.Len()); err != nil {
+					return err
+				}
+
+				m := value.MapRange()
+
+				for m.Next() {
+					if err := encoder.Encode(m.Key()); err != nil {
+						return err
+					}
+
+					if err := encoder.Encode(interfaces(m.Value())); err != nil {
+						return err
+					}
+				}
+
+				return nil
+			default:
+				if err := encoder.getType(reflect.New(elem).Elem()); err != nil {
+					return err
+				}
 			}
 		case reflect.Struct:
 			return encoder.structs(value, true)

--- a/encoder.go
+++ b/encoder.go
@@ -246,7 +246,7 @@ func (encoder *Encoder) getType(value reflect.Value) error {
 			}
 		}
 
-		if err := encoder.Encode(dt.Kind()); err != nil {
+		if err := encoder.Encode(Abs[reflect.Type](dt).Kind()); err != nil {
 			return err
 		}
 
@@ -270,7 +270,9 @@ func (encoder *Encoder) getType(value reflect.Value) error {
 			}
 		}
 
-		if err := encoder.Encode(dt.Kind()); err != nil {
+		kind := Abs[reflect.Type](dt).Kind()
+
+		if err := encoder.Encode(kind); err != nil {
 			return err
 		}
 

--- a/struct.go
+++ b/struct.go
@@ -39,7 +39,7 @@ func (structs *Struct) maps(old reflect.Value) map[interface{}]interface{} {
 	r := old.MapRange()
 
 	for r.Next() {
-		switch v := r.Value().Interface().(type) {
+		switch v := Abs[reflect.Value](r.Value()).Interface().(type) {
 		case Struct:
 			m[r.Key().Interface()] = v.Map()
 		case map[interface{}]interface{}:

--- a/struct.go
+++ b/struct.go
@@ -201,6 +201,31 @@ func (structs *Struct) convert(t reflect.Type, value reflect.Value) reflect.Valu
 		return abs.Convert(t)
 	}
 
+	switch value.Kind() {
+	case reflect.Array, reflect.Slice:
+		tmp := reflect.MakeSlice(t, value.Len(), value.Cap())
+
+		for i := 0; i < value.Len(); i++ {
+			ptr := as2(value.Index(i), reflect.New(t.Elem()).Elem())
+			tmp.Index(i).Set(ptr)
+		}
+
+		value = tmp
+	case reflect.Map:
+		tmp := reflect.MakeMapWithSize(t, value.Len())
+
+		m := value.MapRange()
+		for m.Next() {
+			mk := as2(m.Key(), reflect.New(t.Key()).Elem())
+			mv := as2(m.Value(), reflect.New(t.Elem()).Elem())
+
+			tmp.SetMapIndex(mk, mv)
+		}
+
+		value = tmp
+	default:
+	}
+
 	return value
 }
 

--- a/struct.go
+++ b/struct.go
@@ -59,6 +59,8 @@ func (structs *Struct) maps(old reflect.Value) map[interface{}]interface{} {
 			}
 
 			m[r.Key().Interface()] = v.Interface()
+		case []interface{}:
+			m[r.Key()] = structs.arrays(Abs[reflect.Value](r.Value()))
 		default:
 			m[r.Key().Interface()] = v
 		}

--- a/struct.go
+++ b/struct.go
@@ -1,6 +1,6 @@
 /*
  *     A tiny binary format
- *     Copyright (C) 2024  Dviih
+ *     Copyright (C) 2025  Dviih
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Affero General Public License as published

--- a/struct.go
+++ b/struct.go
@@ -69,6 +69,26 @@ func (structs *Struct) maps(old reflect.Value) map[interface{}]interface{} {
 	return m
 }
 
+func (structs *Struct) arrays(value reflect.Value) []interface{} {
+	var m []interface{}
+
+	for i := 0; i < value.Len(); i++ {
+		element := Abs[reflect.Value](value.Index(i))
+
+		switch element.Interface().(type) {
+		case []interface{}:
+			m = append(m, structs.arrays(element))
+		case Struct:
+			s := element.Interface().(Struct)
+			m = append(m, s.Map())
+		default:
+			m = append(m, element.Interface())
+		}
+	}
+
+	return m
+}
+
 func (structs *Struct) Get(i int) (interface{}, bool) {
 	v, ok := structs.m[i]
 	if !ok {


### PR DESCRIPTION
This pull request fixes `interface{}` within parsing nested arrays of structs and structs inside structs.
Also now relies for maps to use `KeyElem` and requires keys to be comparable.