### PR TITLE
Patch buffer read

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -51,7 +51,13 @@ func (buffer *Buffer) Write(data []byte) (int, error) {
 }
 
 func (buffer *Buffer) Read(data []byte) (int, error) {
-	n := copy(data, buffer.data[buffer.read:buffer.read+int64(len(data))])
+	end := buffer.read + int64(len(data))
+
+	if end > int64(len(buffer.data)) {
+		end = int64(len(buffer.data))
+	}
+
+	n := copy(data, buffer.data[buffer.read:end])
 
 	buffer.read += int64(n)
 

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -1,6 +1,6 @@
 /*
  *     A tiny binary format
- *     Copyright (C) 2024  Dviih
+ *     Copyright (C) 2025  Dviih
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Affero General Public License as published

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -60,11 +60,6 @@ func (buffer *Buffer) Read(data []byte) (int, error) {
 	n := copy(data, buffer.data[buffer.read:end])
 
 	buffer.read += int64(n)
-
-	if len(data) > n {
-		return n, io.EOF
-	}
-
 	return n, nil
 }
 

--- a/encoder.go
+++ b/encoder.go
@@ -268,7 +268,6 @@ func (encoder *Encoder) structs(value reflect.Value, kind bool) error {
 			return err
 		}
 
-		kind := kind
 		if field.Kind() == reflect.Struct {
 			kind = true
 		}


### PR DESCRIPTION
This pull request patches `*Buffer.Read` if the passed `[]byte` length is higher than buffer's causing it to panic as it can't read, the pull request limits the read to `len(buffer.data)`. The `buffer.read` is based on what was read not what `end` is and the `n` returned is from `copy`.
A condition which is impossible to check if `n` is higher than `len(buffer.data)` was removed.
A `kind := kind` was in `encoder` and had to be cut sorry!

Previously reading with a higher buffer would panic.