### PR TITLE
Patch no EOF on `buffer.Read`.

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -60,6 +60,11 @@ func (buffer *Buffer) Read(data []byte) (int, error) {
 	n := copy(data, buffer.data[buffer.read:end])
 
 	buffer.read += int64(n)
+
+	if len(data) > buffer.Len() {
+		return n, io.EOF
+	}
+
 	return n, nil
 }
 


### PR DESCRIPTION
Previously the `io.EOF` error was removed from `buffer.Read` because it was so called "impossible" and indeed it is but some functions require it to EOF like `io.ReadAll` and http related tasks.
The io.EOF is only returned if length of read buffer is over buffer's length. pseudo: `in.length > buffer.length`.