### PR TITLE
Buffer: Wrongly EOF

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -51,6 +51,10 @@ func (buffer *Buffer) Write(data []byte) (int, error) {
 }
 
 func (buffer *Buffer) Read(data []byte) (int, error) {
+	if buffer.read >= int64(len(buffer.data)) {
+		return 0, io.EOF
+	}
+
 	end := buffer.read + int64(len(data))
 
 	if end > int64(len(buffer.data)) {
@@ -60,11 +64,6 @@ func (buffer *Buffer) Read(data []byte) (int, error) {
 	n := copy(data, buffer.data[buffer.read:end])
 
 	buffer.read += int64(n)
-
-	if len(data) > buffer.Len() {
-		return n, io.EOF
-	}
-
 	return n, nil
 }
 


### PR DESCRIPTION
By reading past the buffer's length it was sent an EOF error alongside n which shouldn't be ever the case. I've missed it and I'm sorry so this is a tiny patch that should be long here.
It's simple and changes how to handle EOF from the top so it's fast to determinate EOFs.