### PR TITLE
Purge dependencies + Array of interfaces fixed size patch.

### DIFF
--- a/bin.go
+++ b/bin.go
@@ -29,7 +29,7 @@ var (
 	Invalid              = errors.New("invalid value")
 	CantSet              = errors.New("can't set")
 	TypeMustBeComparable = errors.New("type must be comparable")
-	unexpectedBehaviour  = errors.New("this is a very unexpected behaviour")
+	unexpectedBehavior   = errors.New("this is a very unexpected behavior")
 )
 
 func Value(v interface{}) reflect.Value {

--- a/decoder.go
+++ b/decoder.go
@@ -26,12 +26,7 @@ import (
 )
 
 type Decoder struct {
-	readByte func() (byte, error)
-	reader   io.Reader
-}
-
-func (decoder *Decoder) ReadByte() (byte, error) {
-	return decoder.readByte()
+	reader io.Reader
 }
 
 func (decoder *Decoder) Decode(v interface{}) error {
@@ -70,7 +65,7 @@ func (decoder *Decoder) Decode(v interface{}) error {
 		value.Set(reflect.ValueOf(false))
 		return nil
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		n, err := VarIntOut[int64](decoder)
+		n, err := VarIntOut[int64](decoder.reader)
 		if err != nil {
 			return err
 		}
@@ -78,7 +73,7 @@ func (decoder *Decoder) Decode(v interface{}) error {
 		value.SetInt(n)
 		return nil
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		n, err := VarIntOut[uint64](decoder)
+		n, err := VarIntOut[uint64](decoder.reader)
 		if err != nil {
 			return err
 		}
@@ -86,7 +81,7 @@ func (decoder *Decoder) Decode(v interface{}) error {
 		value.SetUint(n)
 		return nil
 	case reflect.Float32:
-		n, err := VarIntOut[uint32](decoder)
+		n, err := VarIntOut[uint32](decoder.reader)
 		if err != nil {
 			return err
 		}
@@ -115,12 +110,12 @@ func (decoder *Decoder) Decode(v interface{}) error {
 		value.SetComplex(complex128(complex(math.Float32frombits(r), math.Float32frombits(i))))
 		return nil
 	case reflect.Complex128:
-		r, err := VarIntOut[uint64](decoder)
+		r, err := VarIntOut[uint64](decoder.reader)
 		if err != nil {
 			return err
 		}
 
-		i, err := VarIntOut[uint64](decoder)
+		i, err := VarIntOut[uint64](decoder.reader)
 		if err != nil {
 			return err
 		}
@@ -164,7 +159,7 @@ func (decoder *Decoder) Decode(v interface{}) error {
 		value.Set(ptr)
 		return nil
 	case reflect.Map:
-		size, err := VarIntOut[int](decoder)
+		size, err := VarIntOut[int](decoder.reader)
 		if err != nil {
 			return err
 		}
@@ -197,7 +192,7 @@ func (decoder *Decoder) Decode(v interface{}) error {
 
 		return decoder.Decode(value)
 	case reflect.Slice:
-		size, err := VarIntOut[int](decoder)
+		size, err := VarIntOut[int](decoder.reader)
 		if err != nil {
 			return err
 		}
@@ -212,7 +207,7 @@ func (decoder *Decoder) Decode(v interface{}) error {
 
 		return nil
 	case reflect.String:
-		size, err := VarIntOut[int](decoder)
+		size, err := VarIntOut[int](decoder.reader)
 		if err != nil {
 			return err
 		}
@@ -229,7 +224,7 @@ func (decoder *Decoder) Decode(v interface{}) error {
 		fields := (&Struct{}).fields(value)
 
 		for i := 0; i < len(fields); i++ {
-			tag, err := VarIntOut[int](decoder)
+			tag, err := VarIntOut[int](decoder.reader)
 			if err != nil {
 				return err
 			}
@@ -252,7 +247,7 @@ func (decoder *Decoder) Decode(v interface{}) error {
 }
 
 func (decoder *Decoder) structs(value reflect.Value) error {
-	size, err := VarIntOut[int](decoder)
+	size, err := VarIntOut[int](decoder.reader)
 	if err != nil {
 		return err
 	}
@@ -264,7 +259,7 @@ func (decoder *Decoder) structs(value reflect.Value) error {
 	value.Set(reflect.ValueOf(s))
 
 	for i := 0; i < size; i++ {
-		tag, err := VarIntOut[int](decoder)
+		tag, err := VarIntOut[int](decoder.reader)
 		if err != nil {
 			return err
 		}
@@ -295,28 +290,13 @@ func (decoder *Decoder) structs(value reflect.Value) error {
 }
 
 func NewDecoder(reader io.Reader) *Decoder {
-	var byteReader func() (byte, error)
-
-	v, ok := reader.(io.ByteReader)
-	if ok {
-		byteReader = v.ReadByte
-	} else {
-		byteReader = func() (byte, error) {
-			data := make([]byte, 1)
-			_, err := reader.Read(data)
-
-			return data[0], err
-		}
-	}
-
 	return &Decoder{
-		readByte: byteReader,
-		reader:   reader,
+		reader: reader,
 	}
 }
 
 func (decoder *Decoder) getType() (reflect.Type, error) {
-	kind, err := decoder.ReadByte()
+	kind, err := VarIntOut[int](decoder.reader)
 	if err != nil {
 		return nil, err
 	}
@@ -361,7 +341,7 @@ func (decoder *Decoder) getType() (reflect.Type, error) {
 	case reflect.String:
 		return reflect.TypeFor[string](), nil
 	case reflect.Array:
-		d, err := VarIntOut[int](decoder)
+		d, err := VarIntOut[int](decoder.reader)
 		if err != nil {
 			return nil, err
 		}
@@ -373,7 +353,7 @@ func (decoder *Decoder) getType() (reflect.Type, error) {
 
 		var di []int
 		for i := 0; i < d; i++ {
-			n, err := VarIntOut[int](decoder)
+			n, err := VarIntOut[int](decoder.reader)
 			if err != nil {
 				return nil, err
 			}
@@ -388,7 +368,7 @@ func (decoder *Decoder) getType() (reflect.Type, error) {
 
 		return fromDepth(t, d, di), nil
 	case reflect.Slice:
-		d, err := VarIntOut[int](decoder)
+		d, err := VarIntOut[int](decoder.reader)
 		if err != nil {
 			return nil, err
 		}
@@ -402,7 +382,7 @@ func (decoder *Decoder) getType() (reflect.Type, error) {
 
 		if mixed {
 			for i := 0; i < d; i++ {
-				n, err := VarIntOut[int](decoder)
+				n, err := VarIntOut[int](decoder.reader)
 				if err != nil {
 					return nil, err
 				}

--- a/decoder.go
+++ b/decoder.go
@@ -52,12 +52,18 @@ func (decoder *Decoder) Decode(v interface{}) error {
 		value.SetZero()
 		return nil
 	case reflect.Bool:
-		b, err := decoder.ReadByte()
+		b := [1]byte{}
+
+		n, err := decoder.reader.Read(b[:])
 		if err != nil {
 			return err
 		}
 
-		if b == 255 {
+		if n != 1 {
+			return io.EOF
+		}
+
+		if b[0] == 255 {
 			value.Set(reflect.ValueOf(true))
 			return nil
 		}

--- a/decoder.go
+++ b/decoder.go
@@ -21,7 +21,6 @@ package bin
 
 import (
 	"io"
-	"math"
 	"reflect"
 )
 
@@ -92,15 +91,15 @@ func (decoder *Decoder) Decode(v interface{}) error {
 			return err
 		}
 
-		value.SetFloat(float64(math.Float32frombits(n)))
+		value.SetFloat(floatFromBits(n))
 		return nil
 	case reflect.Float64:
-		n, err := VarIntOut[uint64](decoder)
+		n, err := VarIntOut[uint64](decoder.reader)
 		if err != nil {
 			return err
 		}
 
-		value.SetFloat(math.Float64frombits(n))
+		value.SetFloat(floatFromBits(n))
 		return nil
 	case reflect.Complex64:
 		r, err := VarIntOut[uint32](decoder)
@@ -113,7 +112,7 @@ func (decoder *Decoder) Decode(v interface{}) error {
 			return err
 		}
 
-		value.SetComplex(complex128(complex(math.Float32frombits(r), math.Float32frombits(i))))
+		value.SetComplex(complex(floatFromBits(r), floatFromBits(i)))
 		return nil
 	case reflect.Complex128:
 		r, err := VarIntOut[uint64](decoder.reader)
@@ -126,7 +125,7 @@ func (decoder *Decoder) Decode(v interface{}) error {
 			return err
 		}
 
-		value.SetComplex(complex(math.Float64frombits(r), math.Float64frombits(i)))
+		value.SetComplex(complex(floatFromBits(r), floatFromBits(i)))
 		return nil
 	case reflect.Array:
 		for i := 0; i < value.Len(); i++ {

--- a/decoder.go
+++ b/decoder.go
@@ -129,7 +129,7 @@ func (decoder *Decoder) Decode(v interface{}) error {
 		return nil
 	case reflect.Array:
 		for i := 0; i < value.Len(); i++ {
-			if err := decoder.Decode(value.Index(i)); err != nil {
+			if err := decoder.Decode(value.Index(i)); err != nil && err != io.EOF {
 				return err
 			}
 		}

--- a/decoder.go
+++ b/decoder.go
@@ -102,12 +102,12 @@ func (decoder *Decoder) Decode(v interface{}) error {
 		value.SetFloat(floatFromBits(n))
 		return nil
 	case reflect.Complex64:
-		r, err := VarIntOut[uint32](decoder)
+		r, err := VarIntOut[uint32](decoder.reader)
 		if err != nil {
 			return err
 		}
 
-		i, err := VarIntOut[uint32](decoder)
+		i, err := VarIntOut[uint32](decoder.reader)
 		if err != nil {
 			return err
 		}

--- a/decoder.go
+++ b/decoder.go
@@ -148,6 +148,16 @@ func (decoder *Decoder) Decode(v interface{}) error {
 		}
 
 		if t == nil {
+			b := [1]byte{}
+
+			if _, err := decoder.reader.Read(b[:]); err != nil && err != io.EOF {
+				return err
+			}
+
+			if b[0] != 0 {
+				return unexpectedBehavior
+			}
+
 			return nil
 		}
 

--- a/decoder.go
+++ b/decoder.go
@@ -318,7 +318,7 @@ func (decoder *Decoder) getType() (reflect.Type, error) {
 
 	switch reflect.Kind(kind) {
 	case reflect.Invalid:
-		return reflect.TypeOf(nil), nil
+		return nil, nil
 	case reflect.Bool:
 		return reflect.TypeFor[bool](), nil
 	case reflect.Int:

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1,6 +1,6 @@
 /*
  *     A tiny binary format
- *     Copyright (C) 2024  Dviih
+ *     Copyright (C) 2025  Dviih
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Affero General Public License as published

--- a/depth.go
+++ b/depth.go
@@ -21,7 +21,6 @@ package bin
 
 import (
 	"reflect"
-	"slices"
 )
 
 func depth(value reflect.Value) (reflect.Type, int, bool, []int) {
@@ -76,15 +75,13 @@ func isMixed(t reflect.Type) bool {
 }
 
 func fromDepth(t reflect.Type, d int, di []int) reflect.Type {
-	slices.Reverse(di)
-
-	for i := 0; i < d; i++ {
-		if di == nil || di[i] == 0 {
+	for ; d > 0; d-- {
+		if di == nil || di[d-1] == 0 {
 			t = reflect.SliceOf(t)
 			continue
 		}
 
-		t = reflect.ArrayOf(di[i], t)
+		t = reflect.ArrayOf(di[d-1], t)
 	}
 
 	return t

--- a/depth.go
+++ b/depth.go
@@ -1,6 +1,6 @@
 /*
  *     A tiny binary format
- *     Copyright (C) 2024  Dviih
+ *     Copyright (C) 2025  Dviih
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Affero General Public License as published

--- a/encoder.go
+++ b/encoder.go
@@ -22,7 +22,6 @@ package bin
 import (
 	"bytes"
 	"io"
-	"math"
 	"reflect"
 	"strconv"
 )
@@ -60,25 +59,25 @@ func (encoder *Encoder) Encode(v interface{}) error {
 
 		return nil
 	case reflect.Float32:
-		return encoder.Encode(math.Float32bits(float32(value.Float())))
+		return encoder.Encode(floatToBits(float32(value.Float())))
 	case reflect.Float64:
-		return encoder.Encode(math.Float64bits(value.Float()))
+		return encoder.Encode(floatToBits(value.Float()))
 	case reflect.Complex64:
 		c := complex64(value.Complex())
 
-		if err := encoder.Encode(math.Float32bits(real(c))); err != nil {
+		if err := encoder.Encode(floatToBits(real(c))); err != nil {
 			return err
 		}
 
-		return encoder.Encode(math.Float32bits(imag(c)))
+		return encoder.Encode(floatToBits(imag(c)))
 	case reflect.Complex128:
 		c := value.Complex()
 
-		if err := encoder.Encode(math.Float64bits(real(c))); err != nil {
+		if err := encoder.Encode(floatToBits(real(c))); err != nil {
 			return err
 		}
 
-		return encoder.Encode(math.Float64bits(imag(c)))
+		return encoder.Encode(floatToBits(imag(c)))
 	case reflect.Array:
 		for i := 0; i < value.Len(); i++ {
 			if err := encoder.Encode(value.Index(i)); err != nil {

--- a/encoder.go
+++ b/encoder.go
@@ -20,7 +20,6 @@
 package bin
 
 import (
-	"bytes"
 	"io"
 	"reflect"
 	"strconv"
@@ -218,7 +217,7 @@ func (encoder *Encoder) Encode(v interface{}) error {
 			return err
 		}
 
-		if _, err := io.Copy(encoder.writer, bytes.NewBufferString(value.String())); err != nil {
+		if _, err := encoder.writer.Write([]byte(value.String())); err != nil {
 			return err
 		}
 	case reflect.Struct:

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -1,6 +1,6 @@
 /*
  *     A tiny binary format
- *     Copyright (C) 2024  Dviih
+ *     Copyright (C) 2025  Dviih
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Affero General Public License as published

--- a/varint.go
+++ b/varint.go
@@ -105,4 +105,14 @@ func floatToBits[F float32 | float64](f F) interface{} {
 }
 
 	return T(t), nil
+func floatFromBits[V uint32 | uint64](v V) float64 {
+	switch any(v).(type) {
+	case uint32:
+		return float64(*(*float32)(unsafe.Pointer(&v)))
+	case uint64:
+		return *(*float64)(unsafe.Pointer(&v))
+	default:
+		// this should never be reached
+		panic("invalid")
+	}
 }

--- a/varint.go
+++ b/varint.go
@@ -92,7 +92,17 @@ func VarIntOut[T Integer](reader io.Reader) (T, error) {
 	return 0, io.EOF
 }
 
+func floatToBits[F float32 | float64](f F) interface{} {
+	switch any(f).(type) {
+	case float32:
+		return *(*uint32)(unsafe.Pointer(&f))
+	case float64:
+		return *(*uint64)(unsafe.Pointer(&f))
+	default:
+		// this should never be reached
+		panic("invalid")
 	}
+}
 
 	return T(t), nil
 }

--- a/varint.go
+++ b/varint.go
@@ -1,6 +1,6 @@
 /*
  *     A tiny binary format
- *     Copyright (C) 2024  Dviih
+ *     Copyright (C) 2025  Dviih
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Affero General Public License as published
@@ -20,8 +20,9 @@
 package bin
 
 import (
-	"encoding/binary"
 	"io"
+	"reflect"
+	"unsafe"
 )
 
 type Integer = interface {
@@ -29,7 +30,16 @@ type Integer = interface {
 }
 
 func VarIntIn[T Integer](writer io.Writer, t T) error {
-	if _, err := writer.Write(binary.AppendUvarint(nil, uint64(t))); err != nil {
+	b := make([]byte, 0, 10)
+
+	for int(t) >= 0x80 {
+		b = append(b, byte(t)|0x80)
+		t >>= 7
+	}
+
+	b = append(b, byte(t))
+
+	if _, err := writer.Write(b); err != nil {
 		return err
 	}
 

--- a/varint.go
+++ b/varint.go
@@ -21,7 +21,6 @@ package bin
 
 import (
 	"io"
-	"reflect"
 	"unsafe"
 )
 
@@ -30,7 +29,7 @@ type Integer = interface {
 }
 
 func VarIntIn[T Integer](writer io.Writer, t T) error {
-	b := make([]byte, 0, 10)
+	b := make([]byte, 0)
 
 	for int(t) >= 0x80 {
 		b = append(b, byte(t)|0x80)
@@ -104,7 +103,6 @@ func floatToBits[F float32 | float64](f F) interface{} {
 	}
 }
 
-	return T(t), nil
 func floatFromBits[V uint32 | uint64](v V) float64 {
 	switch any(v).(type) {
 	case uint32:


### PR DESCRIPTION
This pull request is focused in using less dependencies that are not already imported by previously.
All dependencies of bin resides within Go's standard library and `reflect`'s required libraries.
Some more code optimization and an array of interface{} patch is also included.