### PR TITLE
Kind

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -35,8 +35,7 @@ func (decoder *Decoder) Decode(v interface{}) error {
 		return CantSet
 	}
 
-	switch value.Type() {
-	case reflect.TypeFor[*Struct]():
+	if value.Type() == reflect.TypeFor[*Struct]() {
 		Zero(value)
 		return decoder.structs(value)
 	}

--- a/kind.go
+++ b/kind.go
@@ -27,12 +27,24 @@ import (
 
 var mkind = &kind.Map{}
 
-
-
-}
-
+func Register[T interface{}](n int, handler kind.Handler) {
+	if n < 128 {
+		panic("invalid kind range")
 	}
 
+	register(n, Abs[reflect.Type](reflect.TypeFor[T]()), handler)
+}
+
+func register(n int, t reflect.Type, handler kind.Handler) {
+	mkind.Store(n, t, handler)
+}
+
+func Alias[T interface{}](n int) {
+	if n < 128 {
+		panic("invalid kind range")
+	}
+
+	mkind.Alias(n, Abs[reflect.Type](reflect.TypeFor[T]()))
 }
 
 

--- a/kind.go
+++ b/kind.go
@@ -29,3 +29,17 @@ type Handler interface {
 	BinInput(*Decoder, reflect.Value)
 }
 
+type kindData struct {
+	Kind    int
+	Type    reflect.Type
+	Handler Handler
+}
+
+type kindMap struct {
+	// mkind map[int]kindData
+	mkind sync.Map
+
+	// mtype map[reflect.Type]kindData
+	mtype sync.Map
+}
+

--- a/kind.go
+++ b/kind.go
@@ -1,0 +1,26 @@
+/*
+ *     A tiny binary format
+ *     Copyright (C) 2025  Dviih
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published
+ *     by the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package bin
+
+import (
+	"reflect"
+	"sync"
+)
+

--- a/kind.go
+++ b/kind.go
@@ -54,3 +54,33 @@ func (m *kindMap) Store(kind int, t reflect.Type, handler Handler) {
 	go m.mtype.Store(t, data)
 }
 
+func (m *kindMap) Get(v interface{}) (int, reflect.Type) {
+	switch v.(type) {
+	case int:
+		kind, ok := m.mkind.Load(v)
+		if !ok {
+			return 0, nil
+		}
+
+		data, ok := kind.(*kindData)
+		if !ok {
+			return 0, nil
+		}
+		return data.Kind, data.Type
+	case reflect.Type:
+		t, ok := m.mtype.Load(v)
+		if !ok {
+			return 0, nil
+		}
+
+		data, ok := t.(*kindData)
+		if !ok {
+			return 0, nil
+		}
+
+		return data.Kind, data.Type
+	default:
+		return 0, nil
+	}
+}
+

--- a/kind.go
+++ b/kind.go
@@ -20,9 +20,12 @@
 package bin
 
 import (
+	"encoding"
+	"github.com/Dviih/bin/kind"
 	"reflect"
 )
 
+var mkind = &kind.Map{}
 
 
 

--- a/kind.go
+++ b/kind.go
@@ -43,3 +43,14 @@ type kindMap struct {
 	mtype sync.Map
 }
 
+func (m *kindMap) Store(kind int, t reflect.Type, handler Handler) {
+	data := &kindData{
+		Kind:    kind,
+		Type:    t,
+		Handler: handler,
+	}
+
+	go m.mkind.Store(kind, data)
+	go m.mtype.Store(t, data)
+}
+

--- a/kind.go
+++ b/kind.go
@@ -21,66 +21,15 @@ package bin
 
 import (
 	"reflect"
-	"sync"
 )
 
-type Handler interface {
-	BinOutput(*Encoder, reflect.Value)
-	BinInput(*Decoder, reflect.Value)
+
+
+
 }
 
-type kindData struct {
-	Kind    int
-	Type    reflect.Type
-	Handler Handler
-}
-
-type kindMap struct {
-	// mkind map[int]kindData
-	mkind sync.Map
-
-	// mtype map[reflect.Type]kindData
-	mtype sync.Map
-}
-
-func (m *kindMap) Store(kind int, t reflect.Type, handler Handler) {
-	data := &kindData{
-		Kind:    kind,
-		Type:    t,
-		Handler: handler,
 	}
 
-	go m.mkind.Store(kind, data)
-	go m.mtype.Store(t, data)
 }
 
-func (m *kindMap) Get(v interface{}) (int, reflect.Type) {
-	switch v.(type) {
-	case int:
-		kind, ok := m.mkind.Load(v)
-		if !ok {
-			return 0, nil
-		}
-
-		data, ok := kind.(*kindData)
-		if !ok {
-			return 0, nil
-		}
-		return data.Kind, data.Type
-	case reflect.Type:
-		t, ok := m.mtype.Load(v)
-		if !ok {
-			return 0, nil
-		}
-
-		data, ok := t.(*kindData)
-		if !ok {
-			return 0, nil
-		}
-
-		return data.Kind, data.Type
-	default:
-		return 0, nil
-	}
-}
 

--- a/kind.go
+++ b/kind.go
@@ -24,3 +24,8 @@ import (
 	"sync"
 )
 
+type Handler interface {
+	BinOutput(*Encoder, reflect.Value)
+	BinInput(*Decoder, reflect.Value)
+}
+

--- a/kind/handler.go
+++ b/kind/handler.go
@@ -21,3 +21,7 @@ package kind
 
 import "reflect"
 
+type Encoder interface {
+	Encode(interface{}) error
+}
+

--- a/kind/handler.go
+++ b/kind/handler.go
@@ -25,3 +25,7 @@ type Encoder interface {
 	Encode(interface{}) error
 }
 
+type Decoder interface {
+	Decode(interface{}) error
+}
+

--- a/kind/handler.go
+++ b/kind/handler.go
@@ -29,3 +29,8 @@ type Decoder interface {
 	Decode(interface{}) error
 }
 
+type Handler interface {
+	Encode(Encoder, reflect.Value) error
+	Decode(Decoder, reflect.Value) error
+}
+

--- a/kind/handler.go
+++ b/kind/handler.go
@@ -1,0 +1,23 @@
+/*
+ *     A tiny binary format
+ *     Copyright (C) 2025  Dviih
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published
+ *     by the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package kind
+
+import "reflect"
+

--- a/kind/handler.go
+++ b/kind/handler.go
@@ -34,3 +34,22 @@ type Handler interface {
 	Decode(Decoder, reflect.Value) error
 }
 
+type ed struct {
+	encode func(Encoder, reflect.Value) error
+	decode func(Decoder, reflect.Value) error
+}
+
+func (m *ed) Encode(encoder Encoder, value reflect.Value) error {
+	return m.encode(encoder, value)
+}
+
+func (m *ed) Decode(decoder Decoder, value reflect.Value) error {
+	return m.decode(decoder, value)
+}
+
+func NewHandler(encode func(Encoder, reflect.Value) error, decode func(Decoder, reflect.Value) error) Handler {
+	return &ed{
+		encode: encode,
+		decode: decode,
+	}
+}

--- a/kind/kind.go
+++ b/kind/kind.go
@@ -24,3 +24,9 @@ import (
 	"sync"
 )
 
+type Data struct {
+	Kind    int
+	Type    reflect.Type
+	Handler Handler
+}
+

--- a/kind/kind.go
+++ b/kind/kind.go
@@ -35,3 +35,14 @@ type Map struct {
 	mtype sync.Map
 }
 
+func (m *Map) Store(kind int, t reflect.Type, handler Handler) {
+	data := &Data{
+		Kind:    kind,
+		Type:    t,
+		Handler: handler,
+	}
+
+	m.mkind.Store(kind, data)
+	m.mtype.Store(t, data)
+}
+

--- a/kind/kind.go
+++ b/kind/kind.go
@@ -46,3 +46,34 @@ func (m *Map) Store(kind int, t reflect.Type, handler Handler) {
 	m.mtype.Store(t, data)
 }
 
+func (m *Map) Load(v interface{}) (int, reflect.Type) {
+	switch v.(type) {
+	case int:
+		kind, ok := m.mkind.Load(v)
+		if !ok {
+			return 0, nil
+		}
+
+		data, ok := kind.(*Data)
+		if !ok {
+			return 0, nil
+		}
+
+		return data.Kind, data.Type
+	case reflect.Type:
+		t, ok := m.mtype.Load(v)
+		if !ok {
+			return 0, nil
+		}
+
+		data, ok := t.(*Data)
+		if !ok {
+			return 0, nil
+		}
+
+		return data.Kind, data.Type
+	default:
+		return 0, nil
+	}
+}
+

--- a/kind/kind.go
+++ b/kind/kind.go
@@ -86,3 +86,34 @@ func (m *Map) Alias(kind int, t reflect.Type) {
 	m.mtype.Store(t, data)
 }
 
+func (m *Map) Run(v, i interface{}, value reflect.Value) (bool, error) {
+	var data *Data
+
+	switch v.(type) {
+	case int:
+		v, ok := m.mkind.Load(v)
+		if !ok {
+			return false, nil
+		}
+
+		data = v.(*Data)
+	case reflect.Type:
+		v, ok := m.mtype.Load(v)
+		if !ok {
+			return false, nil
+		}
+
+		data = v.(*Data)
+	default:
+		return false, nil
+	}
+
+	switch i := i.(type) {
+	case Encoder:
+		return true, data.Handler.Encode(i, value)
+	case Decoder:
+		return true, data.Handler.Decode(i, value)
+	default:
+		return false, nil
+	}
+}

--- a/kind/kind.go
+++ b/kind/kind.go
@@ -30,3 +30,8 @@ type Data struct {
 	Handler Handler
 }
 
+type Map struct {
+	mkind sync.Map
+	mtype sync.Map
+}
+

--- a/kind/kind.go
+++ b/kind/kind.go
@@ -1,0 +1,26 @@
+/*
+ *     A tiny binary format
+ *     Copyright (C) 2025  Dviih
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published
+ *     by the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package kind
+
+import (
+	"reflect"
+	"sync"
+)
+

--- a/kind/kind.go
+++ b/kind/kind.go
@@ -77,3 +77,12 @@ func (m *Map) Load(v interface{}) (int, reflect.Type) {
 	}
 }
 
+func (m *Map) Alias(kind int, t reflect.Type) {
+	data, ok := m.mkind.Load(kind)
+	if !ok {
+		return
+	}
+
+	m.mtype.Store(t, data)
+}
+

--- a/struct.go
+++ b/struct.go
@@ -155,6 +155,11 @@ func (structs *Struct) ranges(fields map[int]reflect.Value) {
 
 		field = Abs[reflect.Value](field)
 
+		if field.Type() == m.Type() {
+			field.Set(m)
+			continue
+		}
+
 		switch field.Kind() {
 		case reflect.Invalid, reflect.Uintptr, reflect.Pointer, reflect.UnsafePointer, reflect.Chan, reflect.Func:
 			continue


### PR DESCRIPTION
This pull request was made based on what was requested at #46 thus adding an extended kind range.

Inside `kind` folder there are quite a lot of powerful tools and where a handler can be added and have direct access to reflection.
The `kind.Handler` enforces that anything must encode and decode thus not splitting it.

The 0-64 is reserved for Go reflection.
65-127 is reserved for standard operations by bin.
128-9223372036854775807 is free for all and must be handled by the own bin in the project.
