### PR TITLE
`int8` and `uint8` does not require VarInt.

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -99,6 +99,20 @@ func (decoder *Decoder) Decode(v interface{}) error {
 
 		value.SetInt(n)
 		return nil
+	case reflect.Uint8:
+		b := [1]byte{}
+
+		n, err := decoder.reader.Read(b[:])
+		if err != nil {
+			return err
+		}
+
+		if n != 1 {
+			return io.EOF
+		}
+
+		value.SetUint(uint64(b[0]))
+		return nil
 	case reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		n, err := VarIntOut[uint64](decoder.reader)
 		if err != nil {

--- a/decoder.go
+++ b/decoder.go
@@ -77,7 +77,7 @@ func (decoder *Decoder) Decode(v interface{}) error {
 
 		value.Set(reflect.ValueOf(false))
 		return nil
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+	case reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64:
 		n, err := VarIntOut[int64](decoder.reader)
 		if err != nil {
 			return err

--- a/decoder.go
+++ b/decoder.go
@@ -99,7 +99,7 @@ func (decoder *Decoder) Decode(v interface{}) error {
 
 		value.SetInt(n)
 		return nil
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+	case reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		n, err := VarIntOut[uint64](decoder.reader)
 		if err != nil {
 			return err

--- a/decoder.go
+++ b/decoder.go
@@ -77,6 +77,20 @@ func (decoder *Decoder) Decode(v interface{}) error {
 
 		value.Set(reflect.ValueOf(false))
 		return nil
+	case reflect.Int8:
+		b := [1]byte{}
+
+		n, err := decoder.reader.Read(b[:])
+		if err != nil {
+			return err
+		}
+
+		if n != 1 {
+			return io.EOF
+		}
+
+		value.SetInt(int64(b[0]))
+		return nil
 	case reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64:
 		n, err := VarIntOut[int64](decoder.reader)
 		if err != nil {

--- a/encoder.go
+++ b/encoder.go
@@ -60,12 +60,12 @@ func (encoder *Encoder) Encode(v interface{}) error {
 			return err
 		}
 		return nil
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 	case reflect.Uint8:
 		if _, err := encoder.writer.Write([]byte{byte(value.Uint())}); err != nil {
 			return err
 		}
 		return nil
+	case reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		if err := VarIntIn(encoder.writer, value.Uint()); err != nil {
 			return err
 		}

--- a/encoder.go
+++ b/encoder.go
@@ -55,7 +55,12 @@ func (encoder *Encoder) Encode(v interface{}) error {
 		}
 
 		return encoder.Encode(0)
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+	case reflect.Int8:
+		if _, err := encoder.writer.Write([]byte{byte(value.Int())}); err != nil {
+			return err
+		}
+		return nil
+	case reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64:
 		if err := VarIntIn(encoder.writer, value.Int()); err != nil {
 			return err
 		}

--- a/encoder.go
+++ b/encoder.go
@@ -61,6 +61,11 @@ func (encoder *Encoder) Encode(v interface{}) error {
 		}
 		return nil
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+	case reflect.Uint8:
+		if _, err := encoder.writer.Write([]byte{byte(value.Uint())}); err != nil {
+			return err
+		}
+		return nil
 		if err := VarIntIn(encoder.writer, value.Uint()); err != nil {
 			return err
 		}

--- a/varint.go
+++ b/varint.go
@@ -21,6 +21,7 @@ package bin
 
 import (
 	"io"
+	"reflect"
 	"unsafe"
 )
 


### PR DESCRIPTION
This pull request removes both types from VarInt lists.